### PR TITLE
BuildRelease.bat build from *_AllInclusive.7z archive

### DIFF
--- a/MediaInfoLib/PrepareSource.sh
+++ b/MediaInfoLib/PrepareSource.sh
@@ -45,7 +45,7 @@ function _get_source () {
 
     # Dependency : zlib
     cd "$WDir"/repos
-    git clone -b "v1.2.8" https://github.com/madler/zlib
+    git clone https://github.com/MediaArea/zlib
 
 }
 

--- a/build_release/BuildRelease.bat
+++ b/build_release/BuildRelease.bat
@@ -7,34 +7,29 @@ rem * You need (Project)-AllInOne, MediaArea-Utils, MediaArea-Utils-Binaries rep
 rem * Code signing certificate is expected to be in %USERPROFILE%\CodeSigningCertificate.p12      *
 rem * Code signing password is expected to be in %USERPROFILE%\CodeSigningCertificate.pass        *
 rem * Patch for MediaInfo donors is expected to be in %USERPROFILE%\MediaInfo_Donors.diff         *
+rem *                                                                                             *
+rem * Command line options:                                                                       *
+rem * - MC or MediaConch: Build MediaConch                                                        *
+rem * - MI or MediaInfo: Build MediaInfo                                                          *
+rem * - /archive: Build from an archive "*_AllInclusive.7z" instead of git repository             *
+rem * - /nosign: Do not try to sign executables                                                   *
 rem ***********************************************************************************************
-
-
 
 rem *** Init ***
 set ERRORLEVEL=
 set BUILD_RELEASE_ERRORCODE=
-if EXIST Release\ (
-    rem buggy rmdir sometimes does not delete all files and directories
-    rmdir Release\ /S /Q
-    rmdir Release\ /S /Q
-    rmdir Release\ /S /Q
-    rmdir Release\ /S /Q
-    if EXIST Release\ (rmdir Release\ /S /Q || exit /b 1)
-    rem sometimes the mkdir just after the rmdir fails
-    timeout /t 3
-)
+set BUILD_MC=
+set BUILD_MI=
+set ARCHIVE=
+set NOSIGN=
+
+if EXIST Release\ call:Rtree Release\ || exit /b 1
+
 mkdir Release\ || exit /b 1
 mkdir Release\download\ || exit /b 1
 mkdir Release\download\binary\ || exit /b 1
-if EXIST ThankYou\ (
-    rem buggy rmdir sometimes does not delete all files and directories
-    rmdir ThankYou\ /S /Q
-    rmdir ThankYou\ /S /Q
-    if EXIST ThankYou\ (rmdir ThankYou\ /S /Q || exit /b 1)
-    rem sometimes the mkdir just after the rmdir fails
-    timeout /t 3
-)
+
+if EXIST ThankYou call:Rtree ThankYou\ || exit /b 1
 
 rem *** Handling of paths for 64-bit compilation ***
 set OLD_PATH=%PATH%
@@ -42,15 +37,28 @@ set OLD_CD=%CD%
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
 set PATH=%PATH%;"C:\Program Files\Git\bin"
 
-rem *** Handling projects ***
-if /I "%1"=="MediaConch"    call:MediaConch     || set BUILD_RELEASE_ERRORCODE=1
-if /I "%1"=="MC"            call:MediaConch     || set BUILD_RELEASE_ERRORCODE=1
-if /I "%1"=="MediaInfo"     call:MediaInfo      || set BUILD_RELEASE_ERRORCODE=1
-if /I "%1"=="MI"            call:MediaInfo      || set BUILD_RELEASE_ERRORCODE=1
-if "%1"=="" (
-                            call:MediaConch     || set BUILD_RELEASE_ERRORCODE=1
-                            call:MediaInfo      || set BUILD_RELEASE_ERRORCODE=1
+rem *** Parse command line ***
+
+:Cmdline
+if not "%1"=="" (
+    if /I "%1"=="MediaConch" set BUILD_MC=1
+    if /I "%1"=="MC" set BUILD_MC=1
+    if /I "%1"=="MediaInfo" set BUILD_MI=1
+    if /I "%1"=="MI" set BUILD_MI=1
+    if /I "%1"=="/archive" set ARCHIVE=1
+    if /I "%1"=="/nosign" set NOSIGN=1
+    shift
+    GOTO:Cmdline
 )
+
+rem *** Handling projects ***
+if "%BUILD_MC%"=="1"    call:MediaConch   || set BUILD_RELEASE_ERRORCODE=1
+if "%BUILD_MI%"=="1"    call:MediaInfo    || set BUILD_RELEASE_ERRORCODE=1
+if "%BUILD_MC%"=="" if "%BUILD_MI%"=="" (
+                        call:MediaConch   || set BUILD_RELEASE_ERRORCODE=1
+                        call:MediaInfo    || set BUILD_RELEASE_ERRORCODE=1
+)
+
 cd %OLD_CD%
 set PATH=%OLD_PATH%
 if "%BUILD_RELEASE_ERRORCODE%"=="1" echo Problem && exit /b 1
@@ -58,13 +66,31 @@ GOTO:EOF
 
 rem *** Global Helpers ***
 
+:Rtree
+rem buggy rmdir sometimes does not delete all files and directories
+if EXIST %~1 rmdir %~1 /s /q
+if EXIST %~1 rmdir %~1 /s /q
+if EXIST %~1 rmdir %~1 /s /q
+if EXIST %~1 rmdir %~1 /s /q
+if EXIST %~1 rmdir %~1 /s /q
+if EXIST %~1 timeout /t 3
+if EXIST %~1 exit /b 1
+GOTO:EOF
+
 :Patch
-cd ..\..\%~1-AllInOne\%~2
-git reset --hard HEAD
-if "%~3" NEQ "" echo Git: %~2_%~3 && git apply --ignore-whitespace "%OLD_CD%\Diff\%~2_%~3.diff" || exit /b 1
-if "%~4" NEQ "" echo Git: %~2_%~4 && git apply --ignore-whitespace "%OLD_CD%\Diff\%~2_%~4.diff" || exit /b 1
-if "%~5" NEQ "" echo Git: %~2_%~5 && git apply --ignore-whitespace "%OLD_CD%\Diff\%~2_%~5.diff" || exit /b 1
-if "%~6" NEQ "" echo Git: %~2_%~6 && git apply --ignore-whitespace "%OLD_CD%\Diff\%~2_%~6.diff" || exit /b 1
+cd %OLD_CD%\..\..\%~1\%~2
+if "%~3" NEQ "" echo Patch: %~2_%~3 && git apply --ignore-whitespace "%OLD_CD%\Diff\%~2_%~3.diff" || exit /b 1
+if "%~4" NEQ "" echo Patch: %~2_%~4 && git apply --ignore-whitespace "%OLD_CD%\Diff\%~2_%~4.diff" || exit /b 1
+if "%~5" NEQ "" echo Patch: %~2_%~5 && git apply --ignore-whitespace "%OLD_CD%\Diff\%~2_%~5.diff" || exit /b 1
+if "%~6" NEQ "" echo Patch: %~2_%~6 && git apply --ignore-whitespace "%OLD_CD%\Diff\%~2_%~6.diff" || exit /b 1
+GOTO:EOF
+
+:RPatch
+cd %OLD_CD%\..\..\%~1\%~2
+if "%~3" NEQ "" echo Reverse Patch: %~2_%~3 && git apply --ignore-whitespace -R "%OLD_CD%\Diff\%~2_%~3.diff" || exit /b 1
+if "%~4" NEQ "" echo Reverse Patch: %~2_%~4 && git apply --ignore-whitespace -R "%OLD_CD%\Diff\%~2_%~4.diff" || exit /b 1
+if "%~5" NEQ "" echo Reverse Patch: %~2_%~5 && git apply --ignore-whitespace -R "%OLD_CD%\Diff\%~2_%~5.diff" || exit /b 1
+if "%~6" NEQ "" echo Reverse Patch: %~2_%~6 && git apply --ignore-whitespace -R "%OLD_CD%\Diff\%~2_%~6.diff" || exit /b 1
 GOTO:EOF
 
 rem ***********************************************************************************************
@@ -73,63 +99,78 @@ rem ****************************************************************************
 
 :MediaConch
 
-rem *** Update ***
-cd ..\..\MediaConch-AllInOne
-git submodule foreach git reset --hard HEAD
-git submodule foreach git clean -f
-git submodule update --init --remote
-cd %OLD_CD%
+rem *** Set sources path ***
+set MC_SOURCES=MediaConch-AllInOne
+if "%ARCHIVE%"=="1" (
+    set MC_SOURCES=mediaconch_AllInclusive
+    cd %OLD_CD%\..\..
+    if EXIST mediaconch_AllInclusive\ call:RTree mediaconch_AllInclusive\ || exit /b 1
+    MediaArea-Utils-Binaries\Windows\7-Zip\7z x -y "mediaconch_*_AllInclusive.7z" || exit /b 1
+    del /q /s mediaconch_AllInclusive\.git 2> nul
+)
+
+rem *** Update git repository ***
+if "%ARCHIVE%"=="" (
+    cd ..\..\%MC_SOURCES%
+    git submodule foreach git reset --hard HEAD
+    git submodule foreach git clean -f
+    git submodule update --init --remote
+    cd %OLD_CD%
+)
 
 rem *** Retrieve version number ***
 cd %OLD_CD%
-for /F "delims=" %%a in ('find "define PRODUCT_VERSION " ..\..\MediaConch-AllInOne\MediaConch\Source\Install\MediaConch_GUI_Windows.nsi') do set "Version=%%a"
+for /F "delims=" %%a in ('find "define PRODUCT_VERSION " ..\..\%MC_SOURCES%\MediaConch\Source\Install\MediaConch_GUI_Windows.nsi') do set "Version=%%a"
 set Version=%Version:!define PRODUCT_VERSION "=%
 set Version=%Version:"=%
 
 rem *** MediaConch CLI and Server ***
 call:Patch_MediaConch
-cd ..\..\MediaConch-AllInOne\MediaConch\Project\MSVC2015
+cd ..\..\%MC_SOURCES%\MediaConch\Project\MSVC2015
 MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=Win32 || exit /b 1
 MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=x64 || exit /b 1
 cd %OLD_CD%
 
 rem *** MediaConch GUI ***
 call:Patch_MediaConch_GUI
-if EXIST ..\..\MediaConch-AllInOne\Qt5.6-msvc2015\ rmdir /S /Q ..\..\MediaConch-AllInOne\Qt5.6-msvc2015\ || exit /b 1
-if EXIST ..\..\MediaConch-AllInOne\Qt5.6-msvc2015_64\ rmdir /S /Q ..\..\MediaConch-AllInOne\Qt5.6-msvc2015_64\ || exit /b 1
-xcopy /S /Q ..\..\MediaArea-Utils-Binaries\Windows\Qt\Qt5.6-msvc2015 ..\..\MediaConch-AllInOne\Qt5.6-msvc2015\ || exit /b 1
-xcopy /S /Q ..\..\MediaArea-Utils-Binaries\Windows\Qt\Qt5.6-msvc2015_64 ..\..\MediaConch-AllInOne\Qt5.6-msvc2015_64\ || exit /b 1
-cd ..\..\MediaConch-AllInOne\MediaConch\Project\MSVC2015
+if EXIST ..\..\%MC_SOURCES%\Qt5.6-msvc2015\ rmdir /S /Q ..\..\%MC_SOURCES%\Qt5.6-msvc2015\ || exit /b 1
+if EXIST ..\..\%MC_SOURCES%\Qt5.6-msvc2015_64\ rmdir /S /Q ..\..\%MC_SOURCES%\Qt5.6-msvc2015_64\ || exit /b 1
+xcopy /S /Q ..\..\MediaArea-Utils-Binaries\Windows\Qt\Qt5.6-msvc2015 ..\..\%MC_SOURCES%\Qt5.6-msvc2015\ || exit /b 1
+xcopy /S /Q ..\..\MediaArea-Utils-Binaries\Windows\Qt\Qt5.6-msvc2015_64 ..\..\%MC_SOURCES%\Qt5.6-msvc2015_64\ || exit /b 1
+cd ..\..\%MC_SOURCES%\MediaConch\Project\MSVC2015
 MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=Win32
 if %ERRORLEVEL% NEQ 0 (
     cd %OLD_CD%
-    rmdir /S /Q ..\..\MediaConch-AllInOne\Qt5.6-msvc2015\
-    rmdir /S /Q ..\..\MediaConch-AllInOne\Qt5.6-msvc2015_64\
+    rmdir /S /Q ..\..\%MC_SOURCES%\Qt5.6-msvc2015\
+    rmdir /S /Q ..\..\%MC_SOURCES%\Qt5.6-msvc2015_64\
     exit /b 1
 )
 MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=x64
 if %ERRORLEVEL% NEQ 0 (
     cd %OLD_CD%
-    rmdir /S /Q ..\..\MediaConch-AllInOne\Qt5.6-msvc2015\
-    rmdir /S /Q ..\..\MediaConch-AllInOne\Qt5.6-msvc2015_64\
+    rmdir /S /Q ..\..\%MC_SOURCES%\Qt5.6-msvc2015\
+    rmdir /S /Q ..\..\%MC_SOURCES%\Qt5.6-msvc2015_64\
     exit /b 1
 )
 cd %OLD_CD%
-rmdir /S /Q ..\..\MediaConch-AllInOne\Qt5.6-msvc2015\
-rmdir /S /Q ..\..\MediaConch-AllInOne\Qt5.6-msvc2015_64\
+rmdir /S /Q ..\..\%MC_SOURCES%\Qt5.6-msvc2015\
+rmdir /S /Q ..\..\%MC_SOURCES%\Qt5.6-msvc2015_64\
 
 rem *** libcurl ***
 cd %OLD_CD%
-copy ..\..\MediaArea-Utils-Binaries\Windows\libcurl\Win32\Release\* ..\..\MediaConch-AllInOne\MediaConch\Project\MSVC2015\Win32\Release\ || exit /b 1
-copy ..\..\MediaArea-Utils-Binaries\Windows\libcurl\x64\Release\* ..\..\MediaConch-AllInOne\MediaConch\Project\MSVC2015\x64\Release\ || exit /b 1
+copy ..\..\MediaArea-Utils-Binaries\Windows\libcurl\Win32\Release\* ..\..\%MC_SOURCES%\MediaConch\Project\MSVC2015\Win32\Release\ || exit /b 1
+copy ..\..\MediaArea-Utils-Binaries\Windows\libcurl\x64\Release\* ..\..\%MC_SOURCES%\MediaConch\Project\MSVC2015\x64\Release\ || exit /b 1
 
 rem *** Signature of executables ***
 set /P CodeSigningCertificatePass= < %USERPROFILE%\CodeSigningCertificate.pass
-signtool sign /f %USERPROFILE%\CodeSigningCertificate.p12 /p %CodeSigningCertificatePass% /fd sha256 /v /tr http://timestamp.geotrust.com/tsa /d MediaConch /du http://mediaarea.net ..\..\MediaConch-AllInOne\MediaConch\Project\MSVC2015\Win32\Release\MediaConch-Server.exe ..\..\MediaConch-AllInOne\MediaConch\Project\MSVC2015\x64\Release\MediaConch-Server.exe ..\..\MediaConch-AllInOne\MediaConch\Project\MSVC2015\Win32\Release\MediaConch.exe ..\..\MediaConch-AllInOne\MediaConch\Project\MSVC2015\x64\Release\MediaConch.exe ..\..\MediaConch-AllInOne\MediaConch\Project\MSVC2015\win32\Release\MediaConch-GUI.exe || set CodeSigningCertificatePass= && exit /b 1
+if "%NOSIGN%"=="" (
+    cd %OLD_CD%
+    signtool sign /f %USERPROFILE%\CodeSigningCertificate.p12 /p %CodeSigningCertificatePass% /fd sha256 /v /tr http://timestamp.geotrust.com/tsa /d MediaConch /du http://mediaarea.net ..\..\%MC_SOURCES%\MediaConch\Project\MSVC2015\Win32\Release\MediaConch-Server.exe ..\..\%MC_SOURCES%\MediaConch\Project\MSVC2015\x64\Release\MediaConch-Server.exe ..\..\%MC_SOURCES%\MediaConch\Project\MSVC2015\Win32\Release\MediaConch.exe ..\..\%MC_SOURCES%\MediaConch\Project\MSVC2015\x64\Release\MediaConch.exe ..\..\%MC_SOURCES%\MediaConch\Project\MSVC2015\win32\Release\MediaConch-GUI.exe || set CodeSigningCertificatePass= && exit /b 1
+)
 set CodeSigningCertificatePass=
 
 rem *** Packages ***
-cd ..\..\MediaConch-AllInOne\MediaConch\Release
+cd ..\..\%MC_SOURCES%\MediaConch\Release
 call Release_CLI_Windows_i386.bat
 call Release_CLI_Windows_x64.bat
 call Release_Server_Windows_i386.bat
@@ -139,26 +180,28 @@ call Release_GUI_Windows_x64.bat
 call Release_GUI_Windows.bat
 
 rem *** Signature of installers ***
-cd %OLD_CD%
 set /P CodeSigningCertificatePass= < %USERPROFILE%\CodeSigningCertificate.pass
-signtool sign /f %USERPROFILE%\CodeSigningCertificate.p12 /p %CodeSigningCertificatePass% /fd sha256 /v /tr http://timestamp.geotrust.com/tsa /d MediaConch /du http://mediaarea.net ..\..\MediaConch-AllInOne\MediaConch\Release\MediaConch_GUI_%Version%_Windows.exe || set CodeSigningCertificatePass= && exit /b 1
+if "%NOSIGN%"=="" (
+    cd %OLD_CD%
+    signtool sign /f %USERPROFILE%\CodeSigningCertificate.p12 /p %CodeSigningCertificatePass% /fd sha256 /v /tr http://timestamp.geotrust.com/tsa /d MediaConch /du http://mediaarea.net ..\..\%MC_SOURCES%\MediaConch\Release\MediaConch_GUI_%Version%_Windows.exe || set CodeSigningCertificatePass= && exit /b 1
+)
 set CodeSigningCertificatePass=
 
 rem *** copy everything at the same place ***
 cd %OLD_CD%
 mkdir Release\download\binary\mediaconch\ || exit /b 1
 mkdir Release\download\binary\mediaconch\%Version%\ || exit /b 1
-copy ..\..\MediaConch-AllInOne\MediaConch\Release\MediaConch_CLI_Windows_i386.zip Release\download\binary\mediaconch\%Version%\MediaConch_CLI_%Version%_Windows_i386.zip || exit /b 1
-copy ..\..\MediaConch-AllInOne\MediaConch\Release\MediaConch_CLI_Windows_x64.zip Release\download\binary\mediaconch\%Version%\MediaConch_CLI_%Version%_Windows_x64.zip || exit /b 1
+copy ..\..\%MC_SOURCES%\MediaConch\Release\MediaConch_CLI_Windows_i386.zip Release\download\binary\mediaconch\%Version%\MediaConch_CLI_%Version%_Windows_i386.zip || exit /b 1
+copy ..\..\%MC_SOURCES%\MediaConch\Release\MediaConch_CLI_Windows_x64.zip Release\download\binary\mediaconch\%Version%\MediaConch_CLI_%Version%_Windows_x64.zip || exit /b 1
 mkdir Release\download\binary\mediaconch-gui\ || exit /b 1
 mkdir Release\download\binary\mediaconch-gui\%Version%\ || exit /b 1
-copy ..\..\MediaConch-AllInOne\MediaConch\Release\MediaConch_GUI_%Version%_Windows.exe Release\download\binary\mediaconch-gui\%Version%\ || exit /b 1
-copy ..\..\MediaConch-AllInOne\MediaConch\Release\MediaConch_GUI_Windows_i386_WithoutInstaller.7z Release\download\binary\mediaconch-gui\%Version%\MediaConch_GUI_%Version%_Windows_i386_WithoutInstaller.7z || exit /b 1
-copy ..\..\MediaConch-AllInOne\MediaConch\Release\MediaConch_GUI_Windows_x64_WithoutInstaller.7z Release\download\binary\mediaconch-gui\%Version%\MediaConch_GUI_%Version%_Windows_x64_WithoutInstaller.7z || exit /b 1
+copy ..\..\%MC_SOURCES%\MediaConch\Release\MediaConch_GUI_%Version%_Windows.exe Release\download\binary\mediaconch-gui\%Version%\ || exit /b 1
+copy ..\..\%MC_SOURCES%\MediaConch\Release\MediaConch_GUI_Windows_i386_WithoutInstaller.7z Release\download\binary\mediaconch-gui\%Version%\MediaConch_GUI_%Version%_Windows_i386_WithoutInstaller.7z || exit /b 1
+copy ..\..\%MC_SOURCES%\MediaConch\Release\MediaConch_GUI_Windows_x64_WithoutInstaller.7z Release\download\binary\mediaconch-gui\%Version%\MediaConch_GUI_%Version%_Windows_x64_WithoutInstaller.7z || exit /b 1
 mkdir Release\download\binary\mediaconch-server\ || exit /b 1
 mkdir Release\download\binary\mediaconch-server\%Version%\ || exit /b 1
-copy ..\..\MediaConch-AllInOne\MediaConch\Release\MediaConch_Server_Windows_i386.zip Release\download\binary\mediaconch-server\%Version%\MediaConch_Server_%Version%_Windows_i386.zip || exit /b 1
-copy ..\..\MediaConch-AllInOne\MediaConch\Release\MediaConch_Server_Windows_x64.zip Release\download\binary\mediaconch-server\%Version%\MediaConch_Server_%Version%_Windows_x64.zip || exit /b 1
+copy ..\..\%MC_SOURCES%\MediaConch\Release\MediaConch_Server_Windows_i386.zip Release\download\binary\mediaconch-server\%Version%\MediaConch_Server_%Version%_Windows_i386.zip || exit /b 1
+copy ..\..\%MC_SOURCES%\MediaConch\Release\MediaConch_Server_Windows_x64.zip Release\download\binary\mediaconch-server\%Version%\MediaConch_Server_%Version%_Windows_x64.zip || exit /b 1
 
 rem *** Reset ***
 GOTO:EOF
@@ -166,43 +209,57 @@ GOTO:EOF
 rem *** Helpers ***
 
 :Patch_MediaConch
-call:Patch MediaConch jansson MT
-call:Patch MediaConch libevent MT
-call:Patch MediaConch libxml2 MT
-call:Patch MediaConch libxslt MT
-call:Patch MediaConch MediaConch MT
-call:Patch MediaConch MediaInfoLib MP MT
-call:Patch MediaConch ZenLib MT
-call:Patch MediaConch zlib MT
+call:Patch %MC_SOURCES% jansson MT
+call:Patch %MC_SOURCES% libevent MT
+call:Patch %MC_SOURCES% libxml2 MT
+call:Patch %MC_SOURCES% libxslt MT
+call:Patch %MC_SOURCES% MediaConch MT
+call:Patch %MC_SOURCES% MediaInfoLib MP MT
+call:Patch %MC_SOURCES% ZenLib MT
+call:Patch %MC_SOURCES% zlib MT
 GOTO:EOF
 
 :Patch_MediaConch_GUI
-call:Patch MediaConch jansson
-call:Patch MediaConch libevent
-call:Patch MediaConch libxml2
-call:Patch MediaConch libxslt
-call:Patch MediaConch MediaConch MD
-call:Patch MediaConch MediaInfoLib MP
-call:Patch MediaConch ZenLib
-call:Patch MediaConch zlib
+call:RPatch %MC_SOURCES% jansson MT
+call:RPatch %MC_SOURCES% libevent MT
+call:RPatch %MC_SOURCES% libxml2 MT
+call:RPatch %MC_SOURCES% libxslt MT
+call:RPatch %MC_SOURCES% MediaConch MT
+call:RPatch %MC_SOURCES% MediaInfoLib MT MP
+call:RPatch %MC_SOURCES% ZenLib MT
+call:RPatch %MC_SOURCES% zlib MT
+call:Patch %MC_SOURCES% MediaConch MD
+call:Patch %MC_SOURCES% MediaInfoLib MP
 GOTO:EOF
 
 rem ***********************************************************************************************
-rem * MediaInfo                                                                                  *
+rem * MediaInfo                                                                                   *
 rem ***********************************************************************************************
 
 :MediaInfo
 
-rem *** Update ***
-cd ..\..\MediaInfo-AllInOne
-git submodule foreach git reset --hard HEAD
-git submodule foreach git clean -f
-git submodule update --init --remote
-cd %OLD_CD%
+rem *** Set sources path ***
+set MI_SOURCES=MediaInfo-AllInOne
+if "%ARCHIVE%"=="1" (
+    set MI_SOURCES=mediainfo_AllInclusive
+    cd %OLD_CD%\..\..
+    if EXIST mediainfo_AllInclusive\ call:Rtree mediainfo_AllInclusive\ || exit /b 1
+    MediaArea-Utils-Binaries\Windows\7-Zip\7z x -y mediainfo_*_AllInclusive.7z || exit /b 1
+    del /q /s mediainfo_AllInclusive\.git 2> nul
+)
+
+rem *** Update git repository ***
+if "%ARCHIVE%"=="" (
+    cd ..\..\%MI_SOURCES%
+    git submodule foreach git reset --hard HEAD
+    git submodule foreach git clean -f
+    git submodule update --init --remote
+    cd %OLD_CD%
+)
 
 rem *** Retrieve version number ***
 cd %OLD_CD%
-for /F "delims=" %%a in ('find "define PRODUCT_VERSION " ..\..\MediaInfo-AllInOne\MediaInfo\Source\Install\MediaInfo_GUI_Windows.nsi') do set "Version=%%a"
+for /F "delims=" %%a in ('find "define PRODUCT_VERSION " ..\..\%MI_SOURCES%\MediaInfo\Source\Install\MediaInfo_GUI_Windows.nsi') do set "Version=%%a"
 set Version=%Version:!define PRODUCT_VERSION "=%
 set Version=%Version:"=%
 
@@ -210,73 +267,86 @@ rem *** MediaInfo global ***
 call:Patch_MediaInfo || exit /b 1
 
 rem *** MediaInfoLib ***
-cd %OLD_CD%\..\..\MediaInfo-AllInOne\MediaInfoLib\Project\MSVC2015
+cd %OLD_CD%\..\..\%MI_SOURCES%\MediaInfoLib\Project\MSVC2015
 MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=Win32 || exit /b 1
 MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=x64 || exit /b 1
 
 rem *** MediaInfo ***
-cd %OLD_CD%\..\..\MediaInfo-AllInOne\MediaInfo\Project\MSVC2015
+cd %OLD_CD%\..\..\%MI_SOURCES%\MediaInfo\Project\MSVC2015
 MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=Win32 || exit /b 1
 MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=x64 || exit /b 1
 call set PATH_TEMP=%PATH%
-call "C:\Program Files (x86)\Embarcadero\RAD Studio\9.0\bin\rsvars.bat"
-cd %OLD_CD%\..\..\MediaInfo-AllInOne\zlib\contrib\BCB && MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=Win32 zlib.cbproj || exit /b 1
-cd %OLD_CD%\..\..\MediaInfo-AllInOne\ZenLib\Project\BCB\Library && MSBuild /maxcpucount:1 /p:Configuration=Release;Platform=Win32 /verbosity:quiet ZenLib.cbproj || exit /b 1
-cd %OLD_CD%\..\..\MediaInfo-AllInOne\MediaInfoLib\Project\BCB\Library && MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=Win32 MediaInfoLib.cbproj || exit /b 1
-cd %OLD_CD%\..\..\MediaInfo-AllInOne\MediaInfoLib\Project\BCB\Dll && MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=Win32 MediaInfo_i386.cbproj || exit /b 1
-cd %OLD_CD%\..\..\MediaInfo-AllInOne\MediaInfo\Project\BCB\GUI && MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=Win32 /t:Build MediaInfo_GUI.cbproj || exit /b 1
+if EXIST "C:\Program Files (x86)\Embarcadero\RAD Studio\9.0\bin\rsvars.bat" (
+    call "C:\Program Files (x86)\Embarcadero\RAD Studio\9.0\bin\rsvars.bat"
+) else (
+    call rsvars.bat
+)
+cd %OLD_CD%\..\..\%MI_SOURCES%\zlib\contrib\BCB && MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=Win32 zlib.cbproj || exit /b 1
+cd %OLD_CD%\..\..\%MI_SOURCES%\ZenLib\Project\BCB\Library && MSBuild /maxcpucount:1 /p:Configuration=Release;Platform=Win32 /verbosity:quiet ZenLib.cbproj || exit /b 1
+cd %OLD_CD%\..\..\%MI_SOURCES%\MediaInfoLib\Project\BCB\Library && MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=Win32 MediaInfoLib.cbproj || exit /b 1
+cd %OLD_CD%\..\..\%MI_SOURCES%\MediaInfoLib\Project\BCB\Dll && MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=Win32 MediaInfo_i386.cbproj || exit /b 1
+cd %OLD_CD%\..\..\%MI_SOURCES%\MediaInfo\Project\BCB\GUI && MSBuild /maxcpucount:1 /verbosity:quiet /p:Configuration=Release;Platform=Win32 /t:Build MediaInfo_GUI.cbproj || exit /b 1
 call set PATH=%PATH_TEMP%
 call set PATH_TEMP=
 
 rem *** Signature of executables ***
-cd %OLD_CD%
 call set /P CodeSigningCertificatePass= < %USERPROFILE%\CodeSigningCertificate.pass
-signtool sign /f %USERPROFILE%\CodeSigningCertificate.p12 /p %CodeSigningCertificatePass% /fd sha256 /v /tr http://timestamp.geotrust.com/tsa /d MediaInfo /du http://mediaarea.net ..\..\MediaInfo-AllInOne\MediaInfoLib\Project\MSVC2015\Win32\Release\MediaInfo.dll ..\..\MediaInfo-AllInOne\MediaInfoLib\Project\MSVC2015\x64\Release\MediaInfo.dll ..\..\MediaInfo-AllInOne\MediaInfo\Project\MSVC2015\Win32\Release\MediaInfo.exe ..\..\MediaInfo-AllInOne\MediaInfoLib\Project\MSVC2015\Win32\Release\MediaInfo_InfoTip.dll ..\..\MediaInfo-AllInOne\MediaInfoLib\Project\MSVC2015\x64\Release\MediaInfo_InfoTip.dll  ..\..\MediaInfo-AllInOne\MediaInfo\Project\MSVC2015\x64\Release\MediaInfo.exe ..\..\MediaInfo-AllInOne\MediaInfo\Project\BCB\GUI\win32\Release\MediaInfo_GUI.exe || set CodeSigningCertificatePass= && exit /b 1
+if "%NOSIGN%"=="" (
+    cd %OLD_CD%
+    signtool sign /f %USERPROFILE%\CodeSigningCertificate.p12 /p %CodeSigningCertificatePass% /fd sha256 /v /tr http://timestamp.geotrust.com/tsa /d MediaInfo /du http://mediaarea.net ..\..\%MI_SOURCES%\MediaInfoLib\Project\MSVC2015\Win32\Release\MediaInfo.dll ..\..\%MI_SOURCES%\MediaInfoLib\Project\MSVC2015\x64\Release\MediaInfo.dll ..\..\%MI_SOURCES%\MediaInfo\Project\MSVC2015\Win32\Release\MediaInfo.exe ..\..\%MI_SOURCES%\MediaInfoLib\Project\MSVC2015\Win32\Release\MediaInfo_InfoTip.dll ..\..\%MI_SOURCES%\MediaInfoLib\Project\MSVC2015\x64\Release\MediaInfo_InfoTip.dll  ..\..\%MI_SOURCES%\MediaInfo\Project\MSVC2015\x64\Release\MediaInfo.exe ..\..\%MI_SOURCES%\MediaInfo\Project\BCB\GUI\win32\Release\MediaInfo_GUI.exe || set CodeSigningCertificatePass= && exit /b 1
+)
 call set CodeSigningCertificatePass=
 
 rem *** Packages ***
-cd %OLD_CD%\..\..\MediaInfo-AllInOne\MediaInfo\Release
+cd %OLD_CD%\..\..\%MI_SOURCES%\MediaInfo\Release
 call Release_CLI_Windows_i386.bat
 call Release_CLI_Windows_x64.bat
 call Release_GUI_Windows_i386.bat
 call Release_GUI_Windows_x64.bat
-cd ..
-git apply --ignore-whitespace "%USERPROFILE%\MediaInfo_Donors.diff" || exit /b 1
-cd Release || exit /b 1
-call Release_GUI_Windows.bat || exit /b 1
-move MediaInfo_GUI_%Version%_Windows.exe MediaInfo_GUI_%Version%_Windows_ThankYou.exe || exit /b 1
-git checkout ..\Source\Install\MediaInfo_GUI_Windows.nsi || exit /b 1
+
+if EXIST "%USERPROFILE%\MediaInfo_Donors.diff" (
+    copy /y ..\Source\Install\MediaInfo_GUI_Windows.nsi ..\Source\Install\MediaInfo_GUI_Windows.nsi.orig || exit /b 1
+    cd .. || exit /b 1
+    git apply --ignore-whitespace "%USERPROFILE%\MediaInfo_Donors.diff" || exit /b 1
+    cd Release || exit /b 1
+    call Release_GUI_Windows.bat || exit /b 1
+    move MediaInfo_GUI_%Version%_Windows.exe MediaInfo_GUI_%Version%_Windows_ThankYou.exe || exit /b 1
+    move /y ..\Source\Install\MediaInfo_GUI_Windows.nsi.orig ..\Source\Install\MediaInfo_GUI_Windows.nsi || exit /b 1
+)
+
 call Release_GUI_Windows.bat
-cd %OLD_CD%\..\..\MediaInfo-AllInOne\MediaInfoLib\Release
+cd %OLD_CD%\..\..\%MI_SOURCES%\MediaInfoLib\Release
 call Release_DLL_Windows_i386.bat
 call Release_DLL_Windows_x64.bat
 
 rem *** Signature of installers ***
-cd %OLD_CD%
 set /P CodeSigningCertificatePass= < %USERPROFILE%\CodeSigningCertificate.pass
-signtool sign /f %USERPROFILE%\CodeSigningCertificate.p12 /p %CodeSigningCertificatePass% /fd sha256 /v /tr http://timestamp.geotrust.com/tsa /d MediaInfo /du http://mediaarea.net ..\..\MediaInfo-AllInOne\MediaInfoLib\Release\MediaInfo_DLL_%Version%_Windows_i386.exe ..\..\MediaInfo-AllInOne\MediaInfoLib\Release\MediaInfo_DLL_%Version%_Windows_x64.exe ..\..\MediaInfo-AllInOne\MediaInfo\Release\MediaInfo_GUI_%Version%_Windows.exe ..\..\MediaInfo-AllInOne\MediaInfo\Release\MediaInfo_GUI_%Version%_Windows_ThankYou.exe || set CodeSigningCertificatePass= && exit /b 1
+if "%NOSIGN%"=="" (
+    cd %OLD_CD%
+    signtool sign /f %USERPROFILE%\CodeSigningCertificate.p12 /p %CodeSigningCertificatePass% /fd sha256 /v /tr http://timestamp.geotrust.com/tsa /d MediaInfo /du http://mediaarea.net ..\..\%MI_SOURCES%\MediaInfoLib\Release\MediaInfo_DLL_%Version%_Windows_i386.exe ..\..\%MI_SOURCES%\MediaInfoLib\Release\MediaInfo_DLL_%Version%_Windows_x64.exe ..\..\%MI_SOURCES%\MediaInfo\Release\MediaInfo_GUI_%Version%_Windows.exe ..\..\%MI_SOURCES%\MediaInfo\Release\MediaInfo_GUI_%Version%_Windows_ThankYou.exe || set CodeSigningCertificatePass= && exit /b 1
+)
 set CodeSigningCertificatePass=
 
 rem *** copy everything at the same place ***
 cd %OLD_CD%
 mkdir ThankYou\ || exit /b 1
 mkdir ThankYou\%Version%\ || exit /b 1
-copy ..\..\MediaInfo-AllInOne\MediaInfo\Release\MediaInfo_GUI_%Version%_Windows_ThankYou.exe ThankYou\%Version%\MediaInfo_GUI_%Version%_Windows.exe || exit /b 1
+copy ..\..\%MI_SOURCES%\MediaInfo\Release\MediaInfo_GUI_%Version%_Windows_ThankYou.exe ThankYou\%Version%\MediaInfo_GUI_%Version%_Windows.exe || exit /b 1
 mkdir Release\download\binary\mediainfo\ || exit /b 1
 mkdir Release\download\binary\mediainfo\%Version%\ || exit /b 1
-copy ..\..\MediaInfo-AllInOne\MediaInfo\Release\MediaInfo_CLI_Windows_i386.zip Release\download\binary\mediainfo\%Version%\MediaInfo_CLI_%Version%_Windows_i386.zip || exit /b 1
-copy ..\..\MediaInfo-AllInOne\MediaInfo\Release\MediaInfo_CLI_Windows_x64.zip Release\download\binary\mediainfo\%Version%\MediaInfo_CLI_%Version%_Windows_x64.zip || exit /b 1
+copy ..\..\%MI_SOURCES%\MediaInfo\Release\MediaInfo_CLI_Windows_i386.zip Release\download\binary\mediainfo\%Version%\MediaInfo_CLI_%Version%_Windows_i386.zip || exit /b 1
+copy ..\..\%MI_SOURCES%\MediaInfo\Release\MediaInfo_CLI_Windows_x64.zip Release\download\binary\mediainfo\%Version%\MediaInfo_CLI_%Version%_Windows_x64.zip || exit /b 1
 mkdir Release\download\binary\mediainfo-gui\ || exit /b 1
 mkdir Release\download\binary\mediainfo-gui\%Version%\ || exit /b 1
-copy ..\..\MediaInfo-AllInOne\MediaInfo\Release\MediaInfo_GUI_%Version%_Windows.exe Release\download\binary\mediainfo-gui\%Version%\ || exit /b 1
-copy ..\..\MediaInfo-AllInOne\MediaInfo\Release\MediaInfo_GUI_Windows_i386_WithoutInstaller.7z Release\download\binary\mediainfo-gui\%Version%\MediaInfo_GUI_%Version%_Windows_i386_WithoutInstaller.7z || exit /b 1
-copy ..\..\MediaInfo-AllInOne\MediaInfo\Release\MediaInfo_GUI_Windows_x64_WithoutInstaller.7z Release\download\binary\mediainfo-gui\%Version%\MediaInfo_GUI_%Version%_Windows_x64_WithoutInstaller.7z || exit /b 1
+copy ..\..\%MI_SOURCES%\MediaInfo\Release\MediaInfo_GUI_%Version%_Windows.exe Release\download\binary\mediainfo-gui\%Version%\ || exit /b 1
+copy ..\..\%MI_SOURCES%\MediaInfo\Release\MediaInfo_GUI_Windows_i386_WithoutInstaller.7z Release\download\binary\mediainfo-gui\%Version%\MediaInfo_GUI_%Version%_Windows_i386_WithoutInstaller.7z || exit /b 1
+copy ..\..\%MI_SOURCES%\MediaInfo\Release\MediaInfo_GUI_Windows_x64_WithoutInstaller.7z Release\download\binary\mediainfo-gui\%Version%\MediaInfo_GUI_%Version%_Windows_x64_WithoutInstaller.7z || exit /b 1
 mkdir Release\download\binary\libmediainfo0\ || exit /b 1
 mkdir Release\download\binary\libmediainfo0\%Version%\ || exit /b 1
-copy ..\..\MediaInfo-AllInOne\MediaInfoLib\Release\MediaInfo_DLL_Windows_i386_WithoutInstaller.7z Release\download\binary\libmediainfo0\%Version%\MediaInfo_DLL_%Version%_Windows_i386_WithoutInstaller.7z || exit /b 1
-copy ..\..\MediaInfo-AllInOne\MediaInfoLib\Release\MediaInfo_DLL_%Version%_Windows_i386.exe Release\download\binary\libmediainfo0\%Version%\ || exit /b 1
-copy ..\..\MediaInfo-AllInOne\MediaInfoLib\Release\MediaInfo_DLL_Windows_x64_WithoutInstaller.7z Release\download\binary\libmediainfo0\%Version%\MediaInfo_DLL_%Version%_Windows_x64_WithoutInstaller.7z || exit /b 1
-copy ..\..\MediaInfo-AllInOne\MediaInfoLib\Release\MediaInfo_DLL_%Version%_Windows_x64.exe Release\download\binary\libmediainfo0\%Version%\ || exit /b 1
+copy ..\..\%MI_SOURCES%\MediaInfoLib\Release\MediaInfo_DLL_Windows_i386_WithoutInstaller.7z Release\download\binary\libmediainfo0\%Version%\MediaInfo_DLL_%Version%_Windows_i386_WithoutInstaller.7z || exit /b 1
+copy ..\..\%MI_SOURCES%\MediaInfoLib\Release\MediaInfo_DLL_%Version%_Windows_i386.exe Release\download\binary\libmediainfo0\%Version%\ || exit /b 1
+copy ..\..\%MI_SOURCES%\MediaInfoLib\Release\MediaInfo_DLL_Windows_x64_WithoutInstaller.7z Release\download\binary\libmediainfo0\%Version%\MediaInfo_DLL_%Version%_Windows_x64_WithoutInstaller.7z || exit /b 1
+copy ..\..\%MI_SOURCES%\MediaInfoLib\Release\MediaInfo_DLL_%Version%_Windows_x64.exe Release\download\binary\libmediainfo0\%Version%\ || exit /b 1
 
 rem *** Reset ***
 GOTO:EOF
@@ -284,8 +354,8 @@ GOTO:EOF
 rem *** Helpers ***
 
 :Patch_MediaInfo
-call:Patch MediaInfo MediaInfo Log MT XP NoGUI || exit /b 1
-call:Patch MediaInfo MediaInfoLib MP MT XP || exit /b 1
-call:Patch MediaInfo ZenLib MT XP || exit /b 1
-call:Patch MediaInfo zlib MT XP || exit /b 1
+call:Patch %MI_SOURCES% MediaInfo Log MT XP NoGUI || exit /b 1
+call:Patch %MI_SOURCES% MediaInfoLib MP MT XP || exit /b 1
+call:Patch %MI_SOURCES% ZenLib MT XP || exit /b 1
+call:Patch %MI_SOURCES% zlib MT XP || exit /b 1
 GOTO:EOF


### PR DESCRIPTION
Ideally, the .bat file should be converted to CRLF EOL to avoid strange behaviors