### PR TITLE
Revert "Clean apt repositories cache"

### DIFF
--- a/build_release/Repo.py
+++ b/build_release/Repo.py
@@ -338,12 +338,6 @@ def Add_deb_package(Package, Name, Version, Arch, Distribution, Release = False)
     subprocess.call(Command, stdout=OUT, stderr=OUT)
 
     # Update repository
-    Command = [ "freight-clear-cache", "-c", os.path.join(Cache_directory, "conf", "freight.conf"),
-                "-g", Configuration["Repo_key"]["key"],
-                "-p", Configuration["Repo_key"]["passfile"],
-                "apt/" + Dist
-              ]"
-
     Command = [ "freight-cache", "-c", os.path.join(Cache_directory, "conf", "freight.conf"),
                 "-g", Configuration["Repo_key"]["key"],
                 "-p", Configuration["Repo_key"]["passfile"],


### PR DESCRIPTION
Not working and unneeded

This reverts commit e6daf0a0c67b51b4f1c872f0d264a7c7a2ac183a.